### PR TITLE
NF-134 parse and process file upload details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-
 # national-import-duty-adjustment-centre
+
+Backend microservice supporting the submission of NIDAC claims from the [national-import-duty-adjustment-centre-frontend](https://github.com/hmrc/national-import-duty-adjustment-centre-frontend) microservice
 
 ## Local Setup
 
@@ -8,7 +9,13 @@
 1. Stop the `service-manager` owned version of the service: `sm --stop NATIONAL_IMPORT_DUTY_ADJUSTMENT_CENTRE`
 1. Start the service: `sbt run`
 
-Ensure you get a 200 response from `curl -i http://localhost:8491/national-import-duty-adjustment-centre/hello-world`
+Ensure you get a JSON response from `curl -i http://localhost:8491/`
+
+## API
+
+| Method | Url | RequestBody | Response | 
+| --- | --- | --- | --- |
+| POST | /create-claim | JSON - [request model](./app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimRequest.scala) | JSON - [response model](./app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala) |
 
 ### License
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimController.scala
@@ -76,7 +76,7 @@ class ClaimController @Inject() (
             }
 
           case error: EISCreateCaseError =>
-            Future.successful(
+            Future(
               BadRequest(
                 Json.toJson(
                   CreateClaimResponse(

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimController.scala
@@ -17,22 +17,33 @@
 package uk.gov.hmrc.nationalimportdutyadjustmentcentre.controllers
 
 import java.util.UUID
+
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.connectors.MicroserviceAuthConnector
-import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.{CreateClaimRequest, CreateClaimResponse, CreateClaimResult}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.{ApiError, EISCreateCaseError, EISCreateCaseRequest, EISCreateCaseSuccess}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentre.services.ClaimService
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.{
+  ApiError,
+  EISCreateCaseError,
+  EISCreateCaseRequest,
+  EISCreateCaseSuccess
+}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.{
+  CreateClaimRequest,
+  CreateClaimResponse,
+  CreateClaimResult
+}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.services.{ClaimService, FileTransferService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton()
 class ClaimController @Inject() (
   val authConnector: MicroserviceAuthConnector,
   cc: ControllerComponents,
-  claimService: ClaimService
+  claimService: ClaimService,
+  fileTransferService: FileTransferService
 )(implicit ec: ExecutionContext)
     extends BackendController(cc) with AuthActions {
 
@@ -50,22 +61,31 @@ class ClaimController @Inject() (
           Content = EISCreateCaseRequest.Content.from(createClaimRequest)
         )
 
-        claimService.createClaim(eisCreateCaseRequest, correlationId) map {
+        claimService.createClaim(eisCreateCaseRequest, correlationId) flatMap {
           case success: EISCreateCaseSuccess =>
-            Created(
-              Json.toJson(
-                CreateClaimResponse(correlationId = correlationId, result = Some(CreateClaimResult(success.CaseID, Seq.empty)))
+            fileTransferService.transfer(success.CaseID, createClaimRequest.uploads) map { uploadResults =>
+              Created(
+                Json.toJson(
+                  CreateClaimResponse(
+                    correlationId = correlationId,
+                    result = Some(CreateClaimResult(success.CaseID, uploadResults))
+                  )
+                )
               )
-            )
+
+            }
+
           case error: EISCreateCaseError =>
-            BadRequest(
-              Json.toJson(
-                CreateClaimResponse(
-                  correlationId = correlationId,
-                  error = Some(
-                    ApiError(
-                      errorCode = error.errorCode.getOrElse("ERROR_UPSTREAM_UNDEFINED"),
-                      errorMessage = error.errorMessage
+            Future.successful(
+              BadRequest(
+                Json.toJson(
+                  CreateClaimResponse(
+                    correlationId = correlationId,
+                    error = Some(
+                      ApiError(
+                        errorCode = error.errorCode.getOrElse("ERROR_UPSTREAM_UNDEFINED"),
+                        errorMessage = error.errorMessage
+                      )
                     )
                   )
                 )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala
@@ -19,9 +19,10 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentre.models
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.ApiError
 
-case class CreateClaimResponse(correlationId: String, error: Option[ApiError] = None, result: Option[String] = None)
+import java.time.LocalDateTime
+
+case class CreateClaimResponse(correlationId: String, error: Option[ApiError] = None, result: Option[CreateClaimResult] = None)
 
 object CreateClaimResponse {
-
   implicit val format: OFormat[CreateClaimResponse] = Json.format[CreateClaimResponse]
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentre.models
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.ApiError
 
-import java.time.LocalDateTime
-
 case class CreateClaimResponse(
   correlationId: String,
   error: Option[ApiError] = None,

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala
@@ -21,7 +21,11 @@ import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.ApiError
 
 import java.time.LocalDateTime
 
-case class CreateClaimResponse(correlationId: String, error: Option[ApiError] = None, result: Option[CreateClaimResult] = None)
+case class CreateClaimResponse(
+  correlationId: String,
+  error: Option[ApiError] = None,
+  result: Option[CreateClaimResult] = None
+)
 
 object CreateClaimResponse {
   implicit val format: OFormat[CreateClaimResponse] = Json.format[CreateClaimResponse]

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResult.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResult.scala
@@ -18,9 +18,8 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentre.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class CreateClaimRequest(userId: String, claimType: String, uploads: Seq[UploadedFile])
+case class CreateClaimResult(caseReference: String, fileTransferResults: Seq[FileTransferResult])
 
-object CreateClaimRequest {
-
-  implicit val format: OFormat[CreateClaimRequest] = Json.format[CreateClaimRequest]
+object CreateClaimResult {
+  implicit val format: OFormat[CreateClaimResult] = Json.format[CreateClaimResult]
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/FileTransferResult.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/FileTransferResult.scala
@@ -18,9 +18,16 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentre.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class CreateClaimRequest(userId: String, claimType: String, uploads: Seq[UploadedFile])
+import java.time.LocalDateTime
 
-object CreateClaimRequest {
+case class FileTransferResult(
+  upscanReference: String,
+  success: Boolean,
+  httpStatus: Int,
+  transferredAt: LocalDateTime,
+  error: Option[String] = None
+)
 
-  implicit val format: OFormat[CreateClaimRequest] = Json.format[CreateClaimRequest]
+object FileTransferResult {
+  implicit val formats: OFormat[FileTransferResult] = Json.format[FileTransferResult]
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/UploadedFile.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/UploadedFile.scala
@@ -18,9 +18,15 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentre.models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class CreateClaimRequest(userId: String, claimType: String, uploads: Seq[UploadedFile])
+case class UploadedFile(
+  upscanReference: String,
+  downloadUrl: String,
+  checksum: String,
+  fileName: String,
+  fileMimeType: String
+)
 
-object CreateClaimRequest {
+object UploadedFile {
 
-  implicit val format: OFormat[CreateClaimRequest] = Json.format[CreateClaimRequest]
+  implicit val formats: OFormat[UploadedFile] = Json.format[UploadedFile]
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferService.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferService.scala
@@ -22,14 +22,18 @@ import java.time.ZonedDateTime
 import scala.concurrent.Future
 
 class FileTransferService {
-  def transfer(caseReference: String, uploads: Seq[UploadedFile]): Future[Seq[FileTransferResult]] = {
+
+  def transfer(caseReference: String, uploads: Seq[UploadedFile]): Future[Seq[FileTransferResult]] =
     Future.successful(
-      uploads.map(upload => FileTransferResult(
-        upscanReference = upload.upscanReference,
-        success = true,
-        httpStatus = 202,
-        transferredAt = ZonedDateTime.now.toLocalDateTime
-      ))
+      uploads.map(
+        upload =>
+          FileTransferResult(
+            upscanReference = upload.upscanReference,
+            success = true,
+            httpStatus = 202,
+            transferredAt = ZonedDateTime.now.toLocalDateTime
+          )
+      )
     )
-  }
+
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferService.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferService.scala
@@ -1,0 +1,19 @@
+package uk.gov.hmrc.nationalimportdutyadjustmentcentre.services
+
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.{FileTransferResult, UploadedFile}
+
+import java.time.ZonedDateTime
+import scala.concurrent.Future
+
+class FileTransferService {
+  def transfer(uploads: Seq[UploadedFile]): Future[Seq[FileTransferResult]]= {
+    Future.successful(
+      uploads.map(upload => FileTransferResult(
+        upscanReference = upload.upscanReference,
+        success = true,
+        httpStatus = 202,
+        transferredAt = ZonedDateTime.now.toLocalDateTime
+      ))
+    )
+  }
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferService.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferService.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.nationalimportdutyadjustmentcentre.services
 
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.{FileTransferResult, UploadedFile}
@@ -6,7 +22,7 @@ import java.time.ZonedDateTime
 import scala.concurrent.Future
 
 class FileTransferService {
-  def transfer(uploads: Seq[UploadedFile]): Future[Seq[FileTransferResult]]= {
+  def transfer(caseReference: String, uploads: Seq[UploadedFile]): Future[Seq[FileTransferResult]] = {
     Future.successful(
       uploads.map(upload => FileTransferResult(
         upscanReference = upload.upscanReference,

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/utils/TestData.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/utils/TestData.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.nationalimportdutyadjustmentcentre.utils
 
-import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.CreateClaimRequest
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.{CreateClaimRequest, UploadedFile}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.{
   EISCreateCaseError,
   EISCreateCaseRequest,
@@ -32,7 +32,18 @@ trait TestData {
     Content = EISCreateCaseRequest.Content.from(createClaimRequest)
   )
 
-  val eisSuccessResponse = EISCreateCaseSuccess("case-id", "processing-date", "status", "status-text")
-  val eisFailResponse    = EISCreateCaseError("timestamp", "correlationId", "errorCode", "errorMessage")
+  def uploadedFiles(upscanReferences: String*): Seq[UploadedFile] = upscanReferences.map(
+    upscanReference =>
+      UploadedFile(
+        upscanReference = upscanReference,
+        downloadUrl = s"downloadURL$upscanReference",
+        checksum = s"checksum$upscanReference",
+        fileName = s"fileName$upscanReference",
+        fileMimeType = s"mimeType$upscanReference"
+      )
+  )
+
+  val eisSuccessResponse: EISCreateCaseSuccess = EISCreateCaseSuccess("case-id", "processing-date", "status", "status-text")
+  val eisFailResponse: EISCreateCaseError    = EISCreateCaseError("timestamp", "correlationId", "errorCode", "errorMessage")
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/utils/TestData.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/utils/TestData.scala
@@ -43,7 +43,10 @@ trait TestData {
       )
   )
 
-  val eisSuccessResponse: EISCreateCaseSuccess = EISCreateCaseSuccess("case-id", "processing-date", "status", "status-text")
-  val eisFailResponse: EISCreateCaseError    = EISCreateCaseError("timestamp", "correlationId", "errorCode", "errorMessage")
+  val eisSuccessResponse: EISCreateCaseSuccess =
+    EISCreateCaseSuccess("case-id", "processing-date", "status", "status-text")
+
+  val eisFailResponse: EISCreateCaseError =
+    EISCreateCaseError("timestamp", "correlationId", "errorCode", "errorMessage")
 
 }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimControllerSpec.scala
@@ -99,7 +99,7 @@ class ClaimControllerSpec extends ControllerSpec with GuiceOneAppPerSuite with T
           Future.successful(eisSuccessResponse)
         )
 
-        val uploadedFiles = Seq(UploadedFile("upscanReference", "downloadURL", "checksum", "fileName", "mimeType"))
+        val uploads = uploadedFiles("upscanReference")
         val fileTransferResults = Seq(
           FileTransferResult(
             upscanReference = "upscanReference",
@@ -109,11 +109,11 @@ class ClaimControllerSpec extends ControllerSpec with GuiceOneAppPerSuite with T
           )
         )
 
-        when(mockFileTransferService.transfer(eisSuccessResponse.CaseID, uploadedFiles)).thenReturn(
+        when(mockFileTransferService.transfer(eisSuccessResponse.CaseID, uploads)).thenReturn(
           Future.successful(fileTransferResults)
         )
 
-        val request = claimRequest.copy(uploads = uploadedFiles)
+        val request = claimRequest.copy(uploads = uploads)
 
         val result: Future[Result] =
           route(app, post.withHeaders(("x-correlation-id", "xyz")).withJsonBody(toJson(request))).get

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimControllerSpec.scala
@@ -30,7 +30,13 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.base.ControllerSpec
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.connectors.MicroserviceAuthConnector
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.{ApiError, EISCreateCaseRequest}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.{CreateClaimRequest, CreateClaimResponse, CreateClaimResult, FileTransferResult, UploadedFile}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.{
+  CreateClaimRequest,
+  CreateClaimResponse,
+  CreateClaimResult,
+  FileTransferResult,
+  UploadedFile
+}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.services.{ClaimService, FileTransferService}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.utils.TestData
 
@@ -41,11 +47,15 @@ class ClaimControllerSpec extends ControllerSpec with GuiceOneAppPerSuite with T
 
   private val claimRequest = CreateClaimRequest("some-id", "some-claim-type", Seq.empty)
 
-  private val mockClaimService = mock[ClaimService]
+  private val mockClaimService        = mock[ClaimService]
   private val mockFileTransferService = mock[FileTransferService]
 
   override lazy val app: Application = GuiceApplicationBuilder()
-    .overrides(bind[MicroserviceAuthConnector].to(mockAuthConnector), bind[ClaimService].to(mockClaimService), bind[FileTransferService].to(mockFileTransferService))
+    .overrides(
+      bind[MicroserviceAuthConnector].to(mockAuthConnector),
+      bind[ClaimService].to(mockClaimService),
+      bind[FileTransferService].to(mockFileTransferService)
+    )
     .build()
 
   override protected def beforeEach(): Unit = {
@@ -90,12 +100,14 @@ class ClaimControllerSpec extends ControllerSpec with GuiceOneAppPerSuite with T
         )
 
         val uploadedFiles = Seq(UploadedFile("upscanReference", "downloadURL", "checksum", "fileName", "mimeType"))
-        val fileTransferResults = Seq(FileTransferResult(
-          upscanReference = "upscanReference",
-          success = true,
-          httpStatus = 202,
-          transferredAt = ZonedDateTime.now.toLocalDateTime
-        ))
+        val fileTransferResults = Seq(
+          FileTransferResult(
+            upscanReference = "upscanReference",
+            success = true,
+            httpStatus = 202,
+            transferredAt = ZonedDateTime.now.toLocalDateTime
+          )
+        )
 
         when(mockFileTransferService.transfer(eisSuccessResponse.CaseID, uploadedFiles)).thenReturn(
           Future.successful(fileTransferResults)

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimControllerSpec.scala
@@ -45,7 +45,7 @@ class ClaimControllerSpec extends ControllerSpec with GuiceOneAppPerSuite with T
   private val mockFileTransferService = mock[FileTransferService]
 
   override lazy val app: Application = GuiceApplicationBuilder()
-    .overrides(bind[MicroserviceAuthConnector].to(mockAuthConnector), bind[ClaimService].to(mockClaimService))
+    .overrides(bind[MicroserviceAuthConnector].to(mockAuthConnector), bind[ClaimService].to(mockClaimService), bind[FileTransferService].to(mockFileTransferService))
     .build()
 
   override protected def beforeEach(): Unit = {
@@ -67,6 +67,9 @@ class ClaimControllerSpec extends ControllerSpec with GuiceOneAppPerSuite with T
       "create-case request succeeds with no files to upload" in {
         when(mockClaimService.createClaim(any[EISCreateCaseRequest], anyString())(any())).thenReturn(
           Future.successful(eisSuccessResponse)
+        )
+        when(mockFileTransferService.transfer(eisSuccessResponse.CaseID, Seq.empty)).thenReturn(
+          Future.successful(Seq.empty)
         )
         val result: Future[Result] =
           route(app, post.withHeaders(("x-correlation-id", "xyz")).withJsonBody(toJson(claimRequest))).get

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/ClaimServiceSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/ClaimServiceSpec.scala
@@ -39,7 +39,7 @@ class ClaimServiceSpec extends UnitSpec with ScalaFutures with TestData {
   val connector: CreateCaseConnector = mock[CreateCaseConnector]
   val service: ClaimService          = new ClaimService(connector)
 
-  val connectorSuccessResponse = mock[EISCreateCaseSuccess]
+  val connectorSuccessResponse: EISCreateCaseSuccess = mock[EISCreateCaseSuccess]
 
   "ClaimService" should {
 
@@ -50,7 +50,7 @@ class ClaimServiceSpec extends UnitSpec with ScalaFutures with TestData {
         when(connector.submitClaim(any[EISCreateCaseRequest], anyString())(any(), any())).thenReturn(
           Future.successful(connectorSuccessResponse)
         )
-        val request  = CreateClaimRequest("user-id", "claimType")
+        val request  = CreateClaimRequest("user-id", "claimType", Seq.empty)
         val response = service.createClaim(eisCreateCaseRequest(request), "xyz").futureValue
 
         response must be(connectorSuccessResponse)

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferServiceSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferServiceSpec.scala
@@ -1,0 +1,26 @@
+package uk.gov.hmrc.nationalimportdutyadjustmentcentre.services
+
+import org.scalatest.concurrent.ScalaFutures
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.base.UnitSpec
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.UploadedFile
+
+class FileTransferServiceSpec extends UnitSpec with ScalaFutures {
+  val service: FileTransferService = new FileTransferService()
+  private val uploadedFile1 = UploadedFile("upscanReference1", "downloadURL1", "checksum1", "fileName1", "mimeType1")
+  private val uploadedFile2 = UploadedFile("upscanReference2", "downloadURL2", "checksum1", "fileName2", "mimeType2")
+
+  "FileTransferService" should {
+    "return a successful FileTransferResult per uploaded file" when {
+      "transferFile called" in {
+
+        val uploadedFiles = Seq(uploadedFile1, uploadedFile2)
+        val transferResults = service.transfer(uploadedFiles).futureValue
+
+        transferResults.length must be(uploadedFiles.length)
+        transferResults.head.upscanReference must be (uploadedFile1.upscanReference)
+        transferResults(1).upscanReference must be (uploadedFile2.upscanReference)
+
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferServiceSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferServiceSpec.scala
@@ -18,23 +18,21 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentre.services
 
 import org.scalatest.concurrent.ScalaFutures
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.base.UnitSpec
-import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.UploadedFile
+import uk.gov.hmrc.nationalimportdutyadjustmentcentre.utils.TestData
 
-class FileTransferServiceSpec extends UnitSpec with ScalaFutures {
+class FileTransferServiceSpec extends UnitSpec with ScalaFutures with TestData {
   val service: FileTransferService = new FileTransferService()
-  private val uploadedFile1        = UploadedFile("upscanReference1", "downloadURL1", "checksum1", "fileName1", "mimeType1")
-  private val uploadedFile2        = UploadedFile("upscanReference2", "downloadURL2", "checksum1", "fileName2", "mimeType2")
 
   "FileTransferService" should {
     "return a successful FileTransferResult per uploaded file" when {
       "transferFile called" in {
 
-        val uploadedFiles   = Seq(uploadedFile1, uploadedFile2)
-        val transferResults = service.transfer("caseReferenceNumber", uploadedFiles).futureValue
+        val uploads         = uploadedFiles("upscanReference1", "upscanReference2")
+        val transferResults = service.transfer("caseReferenceNumber", uploads).futureValue
 
-        transferResults.length must be(uploadedFiles.length)
-        transferResults.head.upscanReference must be(uploadedFile1.upscanReference)
-        transferResults(1).upscanReference must be(uploadedFile2.upscanReference)
+        transferResults.length must be(uploads.length)
+        transferResults.head.upscanReference must be(uploads.head.upscanReference)
+        transferResults(1).upscanReference must be(uploads(1).upscanReference)
 
       }
     }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferServiceSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferServiceSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.nationalimportdutyadjustmentcentre.services
 
 import org.scalatest.concurrent.ScalaFutures
@@ -6,19 +22,19 @@ import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.UploadedFile
 
 class FileTransferServiceSpec extends UnitSpec with ScalaFutures {
   val service: FileTransferService = new FileTransferService()
-  private val uploadedFile1 = UploadedFile("upscanReference1", "downloadURL1", "checksum1", "fileName1", "mimeType1")
-  private val uploadedFile2 = UploadedFile("upscanReference2", "downloadURL2", "checksum1", "fileName2", "mimeType2")
+  private val uploadedFile1        = UploadedFile("upscanReference1", "downloadURL1", "checksum1", "fileName1", "mimeType1")
+  private val uploadedFile2        = UploadedFile("upscanReference2", "downloadURL2", "checksum1", "fileName2", "mimeType2")
 
   "FileTransferService" should {
     "return a successful FileTransferResult per uploaded file" when {
       "transferFile called" in {
 
-        val uploadedFiles = Seq(uploadedFile1, uploadedFile2)
+        val uploadedFiles   = Seq(uploadedFile1, uploadedFile2)
         val transferResults = service.transfer("caseReferenceNumber", uploadedFiles).futureValue
 
         transferResults.length must be(uploadedFiles.length)
-        transferResults.head.upscanReference must be (uploadedFile1.upscanReference)
-        transferResults(1).upscanReference must be (uploadedFile2.upscanReference)
+        transferResults.head.upscanReference must be(uploadedFile1.upscanReference)
+        transferResults(1).upscanReference must be(uploadedFile2.upscanReference)
 
       }
     }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferServiceSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/services/FileTransferServiceSpec.scala
@@ -14,7 +14,7 @@ class FileTransferServiceSpec extends UnitSpec with ScalaFutures {
       "transferFile called" in {
 
         val uploadedFiles = Seq(uploadedFile1, uploadedFile2)
-        val transferResults = service.transfer(uploadedFiles).futureValue
+        val transferResults = service.transfer("caseReferenceNumber", uploadedFiles).futureValue
 
         transferResults.length must be(uploadedFiles.length)
         transferResults.head.upscanReference must be (uploadedFile1.upscanReference)


### PR DESCRIPTION
First increment of processing uploaded files as part of the EIS submission

Adds models to take file upload details in request and include file transfer results in the response.

The transferring of files is handed off to a new service for processing - the initial cut of processing is to echo back "success" for each file

Updates JSON API
```js
// request from
{ "claimType": "Tomatoes", "userId": "WAC" }
// request to
{ "claimType": "Tomatoes", "userId": "WAC", "uploads": [] }

// response from
{
  "correlationId": "1a52f1dd-130c-4334-81a5-aff04e5b39f7",
  "result": "NIDTYW7DDF8GXSSHGRJY4"
}

// response to
{
  "correlationId": "1a52f1dd-130c-4334-81a5-aff04e5b39f7",
  "result": {
    "caseReference": "NIDTYW7DDF8GXSSHGRJY4",
    "fileTransferResults": []
  }
}
```