### PR TITLE
NF-159 Require x-correlation-id header to be provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Ensure you get a JSON response from `curl -i http://localhost:8491/`
 
 ## API
 
-| Method | Url | RequestBody | Response | 
-| --- | --- | --- | --- |
-| POST | /create-claim | JSON - [request model](./app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimRequest.scala) | JSON - [response model](./app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala) |
+| Method | Url | Required Headers | RequestBody | Response | 
+| --- | --- | --- | --- | --- |
+| POST | /create-claim | x-correlation-id | JSON - [request model](./app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimRequest.scala) | JSON - [response model](./app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/CreateClaimResponse.scala) |
 
 ### License
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
@@ -43,7 +43,10 @@ class CreateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
     http.POST[EISCreateCaseRequest, EISCreateCaseResponse](url, request)(
       implicitly[Writes[EISCreateCaseRequest]],
       readFromJsonSuccessOrFailure,
-      hc.copy(authorization = Some(Authorization(s"Bearer ${config.eisAuthorizationToken}")))
+      HeaderCarrier(
+        authorization = Some(Authorization(s"Bearer ${config.eisAuthorizationToken}")),
+        requestId = hc.requestId
+      )
         .withExtraHeaders(pegaApiHeaders(correlationId, config.eisEnvironment): _*),
       implicitly[ExecutionContext]
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/ClaimController.scala
@@ -94,4 +94,5 @@ class ClaimController @Inject() (
       }
     }
   }
+
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/WithCorrelationId.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/WithCorrelationId.scala
@@ -25,8 +25,8 @@ import scala.concurrent.{ExecutionContext, Future}
 trait WithCorrelationId { self: Results =>
 
   protected def withCorrelationId(
-                                   f: String => Future[Result]
-                                 )(implicit ec: ExecutionContext, request: Request[_]): Future[Result] =
+    f: String => Future[Result]
+  )(implicit ec: ExecutionContext, request: Request[_]): Future[Result] =
     request.headers.get("x-correlation-id") match {
       case Some(value) => f(value)
       case None =>

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/WithCorrelationId.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/WithCorrelationId.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentre.controllers
+
+import play.api.libs.json.{JsNumber, JsString, Json}
+import play.api.mvc.{Request, Result}
+import play.api.mvc._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait WithCorrelationId { self: Results =>
+
+  protected def withCorrelationId(
+                                   f: String => Future[Result]
+                                 )(implicit ec: ExecutionContext, request: Request[_]): Future[Result] =
+    request.headers.get("x-correlation-id") match {
+      case Some(value) => f(value)
+      case None =>
+        Future.successful(
+          BadRequest(
+            Json.obj(
+              "statusCode" -> JsNumber(BadRequest.header.status),
+              "message"    -> JsString("Missing header x-correlation-id")
+            )
+          )
+        )
+    }
+
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/WithCorrelationId.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/controllers/WithCorrelationId.scala
@@ -24,20 +24,19 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait WithCorrelationId { self: Results =>
 
+  private val missingXCorrelationIdResponse = BadRequest(
+    Json.obj(
+      "statusCode" -> JsNumber(BadRequest.header.status),
+      "message"    -> JsString("Missing header x-correlation-id")
+    )
+  )
+
   protected def withCorrelationId(
     f: String => Future[Result]
   )(implicit ec: ExecutionContext, request: Request[_]): Future[Result] =
     request.headers.get("x-correlation-id") match {
       case Some(value) => f(value)
-      case None =>
-        Future.successful(
-          BadRequest(
-            Json.obj(
-              "statusCode" -> JsNumber(BadRequest.header.status),
-              "message"    -> JsString("Missing header x-correlation-id")
-            )
-          )
-        )
+      case None        => Future.successful(missingXCorrelationIdResponse)
     }
 
 }


### PR DESCRIPTION
Update EIS create-case connector to specify x-request-id (instead of passing _all_ MDTP headers)