### PR TITLE
NF-272 Update Amend QA stub response to use CaseID from request payload

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/stub/EISUpdateCaseController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/stub/EISUpdateCaseController.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentre.stub
 
 import play.api.libs.json._
 import play.api.mvc.{Action, ControllerComponents}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentre.config.AppConfig
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import java.time.ZonedDateTime
@@ -51,11 +50,13 @@ object UpdateSuccessResponse {
 }
 
 @Singleton()
-class EISUpdateCaseController @Inject() (appConfig: AppConfig, cc: ControllerComponents)(implicit ec: ExecutionContext)
+class EISUpdateCaseController @Inject() (cc: ControllerComponents)(implicit ec: ExecutionContext)
     extends BackendController(cc) {
 
-  def post(): Action[JsValue] = Action.async(parse.json) { _ =>
-    Future(Ok(Json.toJson(UpdateSuccessResponse(CaseID = appConfig.stubPegaCaseRef()))))
+  def post(): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    val caseId: String =
+      (request.body \ "Content" \ "CaseID").toOption.map(_.as[String]).getOrElse("Missing Case ID In Request")
+    Future(Ok(Json.toJson(UpdateSuccessResponse(CaseID = caseId))))
   }
 
 }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/stub/EISUpdateCaseControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/stub/EISUpdateCaseControllerSpec.scala
@@ -20,6 +20,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.{JsString, JsValue, Json}
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -46,13 +47,22 @@ class EISUpdateCaseControllerSpec extends ControllerSpec with GuiceOneAppPerSuit
   "EIS stub update-case" should {
 
     val post = FakeRequest("POST", "/eis-stub/update-case")
+    val payloadWithCaseID: JsValue   = Json.parse("""{"Content": {"CaseID": "NID456345235436435"}}""")
 
-    "return 200 with Json payload containing configured case reference number" in {
+    "return 200 with Json payload containing submitted case reference number" in {
       val result: Future[Result] =
-        route(app, post.withJsonBody(createClaimRequest.eisRequest)).get
+        route(app, post.withJsonBody(payloadWithCaseID)).get
 
       status(result) must be(OK)
-      (contentAsJson(result) \ "CaseID").as[String] must be(configuredRef)
+      (contentAsJson(result) \ "CaseID").as[String] must be("NID456345235436435")
+    }
+
+    "return 200 with Json payload as missing case number" in {
+      val result: Future[Result] =
+        route(app, post.withJsonBody(JsString("randomPayload"))).get
+
+      status(result) must be(OK)
+      (contentAsJson(result) \ "CaseID").as[String] must be("Missing Case ID In Request")
     }
   }
 }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/stub/EISUpdateCaseControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentre/stub/EISUpdateCaseControllerSpec.scala
@@ -46,8 +46,8 @@ class EISUpdateCaseControllerSpec extends ControllerSpec with GuiceOneAppPerSuit
 
   "EIS stub update-case" should {
 
-    val post = FakeRequest("POST", "/eis-stub/update-case")
-    val payloadWithCaseID: JsValue   = Json.parse("""{"Content": {"CaseID": "NID456345235436435"}}""")
+    val post                       = FakeRequest("POST", "/eis-stub/update-case")
+    val payloadWithCaseID: JsValue = Json.parse("""{"Content": {"CaseID": "NID456345235436435"}}""")
 
     "return 200 with Json payload containing submitted case reference number" in {
       val result: Future[Result] =


### PR DESCRIPTION
As this is a temporary stub, I have not implemented a 404 not found, when the CaseID is not in the payload - AFAIK, the front-end should never send a payload without the CaseID, so this scenario should never occur. 
When we know how EIS responds to missing CaseID's we should be in the position to a) implement that in our proper stubs and b) remove this temp stub and use the real EIS serivice in QA.