### PR TITLE
NF-126 Supply EIS headers

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
@@ -35,20 +35,11 @@ class CreateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
 
   val url: String = config.eisBaseUrl + config.eisCreateCaseApiPath
 
-  def submitClaim(request: JsValue, correlationId: String)(implicit
-    hc: HeaderCarrier
-  ): Future[EISCreateCaseResponse] = {
-
-    val eisHc: HeaderCarrier = hc.copy(authorization =
-      Some(Authorization(s"Bearer ${config.eisCreateCaseAuthorizationToken}"))
-    ).withExtraHeaders(pegaApiHeaders(correlationId, config.eisEnvironment): _*)
-
-    http.POST[JsValue, EISCreateCaseResponse](url, request)(
-      implicitly[Writes[JsValue]],
-      readFromJsonSuccessOrFailure,
-      eisHc,
-      implicitly[ExecutionContext]
-    )
-  }
+  def submitClaim(request: JsValue, correlationId: String)(implicit hc: HeaderCarrier): Future[EISCreateCaseResponse] =
+    http.POST[JsValue, EISCreateCaseResponse](
+      url,
+      request,
+      pegaApiHeaders(correlationId, config.eisEnvironment, config.eisCreateCaseAuthorizationToken)
+    )(implicitly[Writes[JsValue]], readFromJsonSuccessOrFailure, hc, implicitly[ExecutionContext])
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
@@ -31,7 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class CreateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(implicit ec: ExecutionContext)
     extends ReadSuccessOrFailure[EISCreateCaseResponse, EISCreateCaseSuccess, EISCreateCaseError](
       EISCreateCaseError.fromStatusAndMessage
-    ) with PegaConnector {
+    ) with EISConnector {
 
   val url: String = config.eisBaseUrl + config.eisCreateCaseApiPath
 
@@ -39,7 +39,7 @@ class CreateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
     http.POST[JsValue, EISCreateCaseResponse](
       url,
       request,
-      pegaApiHeaders(correlationId, config.eisEnvironment, config.eisCreateCaseAuthorizationToken)
+      eisApiHeaders(correlationId, config.eisEnvironment, config.eisCreateCaseAuthorizationToken)
     )(implicitly[Writes[JsValue]], readFromJsonSuccessOrFailure, hc, implicitly[ExecutionContext])
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
@@ -40,6 +40,11 @@ class CreateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
       url,
       request,
       eisApiHeaders(correlationId, config.eisEnvironment, config.eisCreateCaseAuthorizationToken)
-    )(implicitly[Writes[JsValue]], readFromJsonSuccessOrFailure, hc, implicitly[ExecutionContext])
+    )(
+      implicitly[Writes[JsValue]],
+      readFromJsonSuccessOrFailure,
+      hc.copy(authorization = None),
+      implicitly[ExecutionContext]
+    )
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/EISConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/EISConnector.scala
@@ -20,15 +20,15 @@ import java.time.format.DateTimeFormatter
 import java.time.{ZoneId, ZonedDateTime}
 import java.{util => ju}
 
-/** Provides PEGA API headers */
-trait PegaConnector {
+/** Provides EIS API headers */
+trait EISConnector {
 
   private final val httpDateFormat = DateTimeFormatter
     .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", ju.Locale.ENGLISH)
     .withZone(ZoneId.of("GMT"))
 
-  /** Headers required by the PEGA API */
-  final def pegaApiHeaders(correlationId: String, environment: String, token: String): Seq[(String, String)] =
+  /** Headers required by the EIS API */
+  final def eisApiHeaders(correlationId: String, environment: String, token: String): Seq[(String, String)] =
     Seq(
       "x-correlation-id"    -> correlationId,
       "CustomProcessesHost" -> "Digital",

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/PegaConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/PegaConnector.scala
@@ -28,13 +28,14 @@ trait PegaConnector {
     .withZone(ZoneId.of("GMT"))
 
   /** Headers required by the PEGA API */
-  final def pegaApiHeaders(correlationId: String, environment: String): Seq[(String, String)] =
+  final def pegaApiHeaders(correlationId: String, environment: String, token: String): Seq[(String, String)] =
     Seq(
       "x-correlation-id"    -> correlationId,
       "CustomProcessesHost" -> "Digital",
       "date"                -> httpDateFormat.format(ZonedDateTime.now),
       "accept"              -> "application/json",
-      "environment"         -> environment
+      "environment"         -> environment,
+      "Authorization"       -> s"Bearer $token"
     )
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/UpdateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/UpdateCaseConnector.scala
@@ -40,6 +40,11 @@ class UpdateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
       url,
       request,
       eisApiHeaders(correlationId, config.eisEnvironment, config.eisUpdateCaseAuthorizationToken)
-    )(implicitly[Writes[JsValue]], readFromJsonSuccessOrFailure, hc, implicitly[ExecutionContext])
+    )(
+      implicitly[Writes[JsValue]],
+      readFromJsonSuccessOrFailure,
+      hc.copy(authorization = None),
+      implicitly[ExecutionContext]
+    )
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/UpdateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/UpdateCaseConnector.scala
@@ -31,7 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class UpdateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(implicit ec: ExecutionContext)
     extends ReadSuccessOrFailure[EISUpdateCaseResponse, EISUpdateCaseSuccess, EISUpdateCaseError](
       EISUpdateCaseError.fromStatusAndMessage
-    ) with PegaConnector {
+    ) with EISConnector {
 
   val url: String = config.eisBaseUrl + config.eisUpdateCaseApiPath
 
@@ -39,7 +39,7 @@ class UpdateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
     http.POST[JsValue, EISUpdateCaseResponse](
       url,
       request,
-      pegaApiHeaders(correlationId, config.eisEnvironment, config.eisUpdateCaseAuthorizationToken)
+      eisApiHeaders(correlationId, config.eisEnvironment, config.eisUpdateCaseAuthorizationToken)
     )(implicitly[Writes[JsValue]], readFromJsonSuccessOrFailure, hc, implicitly[ExecutionContext])
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/UpdateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/UpdateCaseConnector.scala
@@ -35,20 +35,11 @@ class UpdateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
 
   val url: String = config.eisBaseUrl + config.eisUpdateCaseApiPath
 
-  def updateClaim(request: JsValue, correlationId: String)(implicit
-    hc: HeaderCarrier
-  ): Future[EISUpdateCaseResponse] = {
-
-    val eisHc: HeaderCarrier = hc.copy(authorization =
-      Some(Authorization(s"Bearer ${config.eisUpdateCaseAuthorizationToken}"))
-    ).withExtraHeaders(pegaApiHeaders(correlationId, config.eisEnvironment): _*)
-
-    http.POST[JsValue, EISUpdateCaseResponse](url, request)(
-      implicitly[Writes[JsValue]],
-      readFromJsonSuccessOrFailure,
-      eisHc,
-      implicitly[ExecutionContext]
-    )
-  }
+  def updateClaim(request: JsValue, correlationId: String)(implicit hc: HeaderCarrier): Future[EISUpdateCaseResponse] =
+    http.POST[JsValue, EISUpdateCaseResponse](
+      url,
+      request,
+      pegaApiHeaders(correlationId, config.eisEnvironment, config.eisUpdateCaseAuthorizationToken)
+    )(implicitly[Writes[JsValue]], readFromJsonSuccessOrFailure, hc, implicitly[ExecutionContext])
 
 }


### PR DESCRIPTION
Provide headers directly rather than via HeaderCarrier instance - the HTTP verbs internals only pull headers from the HeaderCarrier instance for "internal" requests

This is as per the this behaviour:
https://github.com/hmrc/http-verbs/blob/12f5c5b34cb00919bce4589ba885f9d70258b836/http-verbs-common/src/test/scala/uk/gov/hmrc/http/HeaderCarrierSpec.scala#L67