### PR TITLE
BAU - make ApiError.errorCode mandatory

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/CreateCaseConnector.scala
@@ -23,7 +23,8 @@ import uk.gov.hmrc.nationalimportdutyadjustmentcentre.config.AppConfig
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.{
   EISCreateCaseError,
   EISCreateCaseResponse,
-  EISCreateCaseSuccess
+  EISCreateCaseSuccess,
+  EISErrorDetail
 }
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,6 +46,11 @@ class CreateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
       readFromJsonSuccessOrFailure,
       hc.copy(authorization = None),
       implicitly[ExecutionContext]
-    )
+    ) recover {
+      case error: UpstreamErrorResponse =>
+        EISCreateCaseError(
+          EISErrorDetail(errorCode = Some(s"ERROR${error.statusCode}"), errorMessage = Some(error.message))
+        )
+    }
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/ReadSuccessOrFailure.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/ReadSuccessOrFailure.scala
@@ -20,6 +20,7 @@ import play.api.libs.json.{JsError, JsSuccess, Reads}
 import play.mvc.Http.{HeaderNames, MimeTypes}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HttpReads, HttpResponse, JsValidationException, UpstreamErrorResponse}
+import uk.gov.hmrc.http.UnsupportedMediaTypeException
 
 import scala.util.Try
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/UpdateCaseConnector.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/connectors/UpdateCaseConnector.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.{JsValue, Writes}
 import uk.gov.hmrc.http.{HeaderCarrier, _}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.config.AppConfig
 import uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis.{
+  EISErrorDetail,
   EISUpdateCaseError,
   EISUpdateCaseResponse,
   EISUpdateCaseSuccess
@@ -45,6 +46,11 @@ class UpdateCaseConnector @Inject() (val config: AppConfig, val http: HttpPost)(
       readFromJsonSuccessOrFailure,
       hc.copy(authorization = None),
       implicitly[ExecutionContext]
-    )
+    ) recover {
+      case error: UpstreamErrorResponse =>
+        EISUpdateCaseError(
+          EISErrorDetail(errorCode = Some(s"ERROR${error.statusCode}"), errorMessage = Some(error.message))
+        )
+    }
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/eis/ApiError.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentre/models/eis/ApiError.scala
@@ -18,8 +18,12 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentre.models.eis
 
 import play.api.libs.json.{Format, Json}
 
-case class ApiError(errorCode: Option[String], errorMessage: Option[String] = None)
+case class ApiError(errorCode: String, errorMessage: Option[String] = None)
 
 object ApiError {
   implicit val formats: Format[ApiError] = Json.format[ApiError]
+
+  def apply(errorCode: Option[String], errorMessage: Option[String]): ApiError =
+    new ApiError(errorCode.getOrElse("UNKNOWN"), errorMessage)
+
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,7 +92,7 @@ metrics {
 # Microservice specific config
 
 auditing {
-  enabled = true
+  enabled = false
   traceRequests = true
   consumer {
     baseUri {

--- a/it/uk/gov/hmrc/nationalimportdutyadjustmentcentre/support/stubs/CreateCaseStubs.scala
+++ b/it/uk/gov/hmrc/nationalimportdutyadjustmentcentre/support/stubs/CreateCaseStubs.scala
@@ -72,6 +72,9 @@ trait CreateCaseStubs {
   def givenCreateCaseResponseWithContentType(contentType: String): Unit =
     stubForPostWithResponse(200, successResponseJson, contentType)
 
+  def givenCreateCaseResponsePlainTextError(status: Int = 500, body: String = "plain error message"): Unit =
+    stubForPostWithResponse(status, body, MimeTypes.TEXT)
+
   private def stubForPostWithResponse(status: Int, responseBody: String, contentType: String = MimeTypes.JSON): Unit =
     stubFor(
       post(urlEqualTo(UPDATE_CASE_URL))

--- a/it/uk/gov/hmrc/nationalimportdutyadjustmentcentre/support/stubs/UpdateCaseStubs.scala
+++ b/it/uk/gov/hmrc/nationalimportdutyadjustmentcentre/support/stubs/UpdateCaseStubs.scala
@@ -72,6 +72,9 @@ trait UpdateCaseStubs {
   def givenUpdateCaseResponseWithContentType(contentType: String): Unit =
     stubForPostWithResponse(200, successResponseJson, contentType)
 
+  def givenUpdateCaseResponsePlainTextError(status: Int = 500, body: String = "plain error message"): Unit =
+    stubForPostWithResponse(status, body, MimeTypes.TEXT)
+
   private def stubForPostWithResponse(status: Int, responseBody: String, contentType: String = MimeTypes.JSON): Unit =
     stubFor(
       post(urlEqualTo(UPDATE_CASE_URL))


### PR DESCRIPTION
- handle "plain text" responses from EIS